### PR TITLE
Blacklist of target inventory lists

### DIFF
--- a/api/injector.lua
+++ b/api/injector.lua
@@ -75,7 +75,7 @@ local function on_player_receive_fields(player, formname, fields)
     logistica.injector_set_put_into_state(pos, 4, fields[CBX_TRA])
   elseif fields[PULL_LIST_PICKER] then -- this has to be last, because its always sent
     local selected = fields[PULL_LIST_PICKER]
-    if logistica.is_allowed_pull_list(selected) then
+    if logistica.is_allowed_pull_list(pos, selected) then
       logistica.set_injector_target_list(pos, selected)
     end
   end

--- a/api/requester.lua
+++ b/api/requester.lua
@@ -75,7 +75,7 @@ local function on_player_receive_fields(player, formname, fields)
     show_requester_formspec(player:get_player_name(), pos)
   elseif fields[PUSH_LIST_PICKER] then
     local selected = fields[PUSH_LIST_PICKER]
-    if logistica.is_allowed_push_list(selected) then
+    if logistica.is_allowed_push_list(pos, selected) then
       local pos = requesterForms[playerName].position
       if not pos then return false end
       logistica.set_requester_target_list(pos, selected)

--- a/util/ui_logic.lua
+++ b/util/ui_logic.lua
@@ -16,19 +16,28 @@ local allowedPush = {
     ["shift"] = true
 }
 
+local disallowedPush = {
+    ["techage:ta4_recipeblock"] = {["input"] = true},
+    ["techage:ta4_pusher_pas"] = {["main"] = true},
+    ["techage:ta4_pusher_act"] = {["main"] = true},
+    ["techage:ta5_hl_chest"] = {["main"] = true},
+    ["techage:ta3_doorcontroller2"] = {["main"] = true},
+    ["techage:ta4_movecontroller2"] = {["main"] = true}
+}
+
 local disallowedPull = {
-    ["techage:ta2_autocrafter_pas"] = {"output"},
-    ["techage:ta2_autocrafter_act"] = {"output"},
-    ["techage:ta3_autocrafter_pas"] = {"output"},
-    ["techage:ta3_autocrafter_act"] = {"output"},
-    ["techage:ta4_autocrafter_pas"] = {"output"},
-    ["techage:ta4_autocrafter_act"] = {"output"},
-    ["techage:ta4_recipeblock"] = {"output","input"},
-    ["techage:techage:ta4_pusher_pas"] = {"main"},
-    ["techage:techage:ta4_pusher_act"] = {"main"},
-    ["techage:ta5_hl_chest"] = {"main"},
-    ["techage:ta3_doorcontroller2"] = {"main"},
-    ["techage:ta4_movecontroller2"] = {"main"}
+    ["techage:ta2_autocrafter_pas"] = {["output"] = true},
+    ["techage:ta2_autocrafter_act"] = {["output"] = true},
+    ["techage:ta3_autocrafter_pas"] = {["output"] = true},
+    ["techage:ta3_autocrafter_act"] = {["output"] = true},
+    ["techage:ta4_autocrafter_pas"] = {["output"] = true},
+    ["techage:ta4_autocrafter_act"] = {["output"] = true},
+    ["techage:ta4_recipeblock"] = {["output"] = true},
+    ["techage:ta4_pusher_pas"] = {["main"] = true},
+    ["techage:ta4_pusher_act"] = {["main"] = true},
+    ["techage:ta5_hl_chest"] = {["main"] = true},
+    ["techage:ta3_doorcontroller2"] = {["main"] = true},
+    ["techage:ta4_movecontroller2"] = {["main"] = true}
 }
 
 -- this MUST be a subset of the allowed push list above
@@ -39,9 +48,9 @@ local logisticaBucketEmptierAllowedPush = {
 local function get_lists(targetPosition, usePushLists)
     logistica.load_position(targetPosition)
     local node = minetest.get_node(targetPosition)
-    local disallowedList = disallowedPull[node.name]
 
     local allowedLists = {}
+    local disallowedList
     if logistica.GROUPS.bucket_emptiers.is(node.name) then
         if usePushLists then
             allowedLists = logisticaBucketEmptierAllowedPush
@@ -51,22 +60,20 @@ local function get_lists(targetPosition, usePushLists)
     elseif logistica.is_machine(node.name) then
         return {}
     elseif usePushLists then
+        disallowedList = disallowedPush[node.name] or {}
         allowedLists = allowedPush
-    elseif disallowedList then
-        for _, inventory in pairs(disallowedList) do
-            allowedPull[inventory] = nil
-        end
-            allowedLists = allowedPull
     else
+        disallowedList = disallowedPull[node.name] or {}
         allowedLists = allowedPull
     end
-
-    --  else allowedLists = allowedPull end
 
     local availableLists = minetest.get_meta(targetPosition):get_inventory():get_lists()
     local lists = {}
     for name, _ in pairs(availableLists) do
-        if allowedLists[name] then
+        for _, inventory in pairs(disallowedList) do
+            allowedLists[inventory] = nil
+        end
+        if allowedLists[name] and not disallowedList[name] then
             table.insert(lists, name)
         end
     end
@@ -87,12 +94,18 @@ function logistica.get_pull_lists(targetPosition)
     return get_lists(targetPosition, false)
 end
 
-function logistica.is_allowed_pull_list(listName)
-    return allowedPull[listName] == true
+function logistica.is_allowed_pull_list(pos, listName)
+    local targetNode = minetest.get_node(logistica.get_injector_target(pos))
+    local disallowedList = disallowedPull[targetNode.name]
+    return (allowedPull[listName] == true) and
+            not (disallowedList and disallowedList[listName] == true)
 end
 
-function logistica.is_allowed_push_list(listName)
-    return allowedPush[listName] == true
+function logistica.is_allowed_push_list(pos, listName)
+    local targetNode = minetest.get_node(logistica.get_requester_target(pos))
+    local disallowedList = disallowedPush[targetNode.name]
+    return (allowedPush[listName] == true) and
+            not (disallowedList and disallowedList[listName] == true)
 end
 
 function logistica.add_allowed_push_list(listName)

--- a/util/ui_logic.lua
+++ b/util/ui_logic.lua
@@ -70,9 +70,6 @@ local function get_lists(targetPosition, usePushLists)
     local availableLists = minetest.get_meta(targetPosition):get_inventory():get_lists()
     local lists = {}
     for name, _ in pairs(availableLists) do
-        for _, inventory in pairs(disallowedList) do
-            allowedLists[inventory] = nil
-        end
         if allowedLists[name] and not disallowedList[name] then
             table.insert(lists, name)
         end


### PR DESCRIPTION
TODO:
- [x] testing
- [x] `main` invlists are still allowed, (presumably) because of this:  
<https://github.com/z-op/logistica/blob/ccc7284ad36cd361d2cdfb6a0e944c8e1f5ef14c/api/requester.lua#L106>  
<https://github.com/z-op/logistica/blob/ccc7284ad36cd361d2cdfb6a0e944c8e1f5ef14c/api/injector.lua#L105>
